### PR TITLE
Add test case for #8

### DIFF
--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -77,3 +77,19 @@ class ReverseOneToOneSideloadSerializer(SideloadSerializer):
     class Meta:
         base_serializer = ReverseOneToOneSerializer
         sideloads = [(OneToOne, OneToOneSerializer)]
+
+class ChildSerializerUsingParentContext(serializers.ModelSerializer):
+    class Meta:
+        model = ChildModel
+        fields = ('value_from_parent_context',)
+
+    value_from_parent_context = serializers.SerializerMethodField()
+
+    def get_value_from_parent_context(self, instance):
+        return self.context['some_value']
+
+class ParentSideloadSerializerWithContext(SideloadSerializer):
+    class Meta:
+        model = ParentModel
+        base_serializer = ParentSerializer
+        sideloads = [(ChildModel, ChildSerializerUsingParentContext)]

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -9,7 +9,8 @@ from tests.models import ChildModel, ParentModel, OptionalChildModel, \
     OneToOne, ReverseOneToOne
 from tests.serializers import ChildSideloadSerializer, \
     OptionalChildSideloadSerializer, OneToOneSideloadSerializer, \
-    ReverseOneToOneSideloadSerializer, ChildSerializer, ParentSideloadSerializer
+    ReverseOneToOneSideloadSerializer, ChildSerializer, \
+    ParentSideloadSerializer, ParentSideloadSerializerWithContext
 
 
 class TestSideloadSerializer(TestCase):
@@ -228,3 +229,21 @@ class TestSideloadListSerializer(TestCase):
             ]
         }
         self.assertEqual(result, expected)
+
+
+class TestChildrenCanAccessParentContext(TestCase):
+
+    def test_children_can_access_parent_context(self):
+        parent = ParentModel.objects.create()
+        old_parent = ParentModel.objects.create()
+        ChildModel.objects.create(parent=parent, old_parent=old_parent)
+
+        serializer = ParentSideloadSerializerWithContext(
+            parent,
+            context={'some_value': 'my value'}
+        )
+
+        self.assertEquals(
+            serializer.data['child_models'][0]['value_from_parent_context'],
+            'my value'
+        )


### PR DESCRIPTION
This is a test case to test that sideloaded serializers can access the context of their parent serializer (#8). The test seems a bit too integrated, compared to the other ones. Tell me if I should do it differently.