### PR TITLE
flake8 and corrected import to collections

### DIFF
--- a/ember_drf/serializers.py
+++ b/ember_drf/serializers.py
@@ -1,12 +1,11 @@
-from collections import defaultdict, namedtuple
+from collections import defaultdict, namedtuple, OrderedDict
 from inflection import pluralize, underscore
 
 from django.db.models.query import QuerySet
 
-from rest_framework.compat import OrderedDict
 from rest_framework.fields import empty
 from rest_framework.serializers import (
-    ListSerializer, Serializer, ValidationError, LIST_SERIALIZER_KWARGS
+    ListSerializer, Serializer, LIST_SERIALIZER_KWARGS
 )
 from rest_framework.utils.model_meta import get_field_info
 from rest_framework.utils.serializer_helpers import ReturnDict


### PR DESCRIPTION
Hi,

Django and rest framework uses OrderedDict from standard library collections so I changed imports. Newest django-rest-framework hasnt OrderedDict in compat.

Another fix is removed unused import. 

best Regards
